### PR TITLE
Add dockerized version of Examples website for ease of use

### DIFF
--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -3,8 +3,28 @@
 LWS comes with a website with examples. You can find the site in the `/examples` folder of this
 repository.
 
+## Dockerized Examples website
+A Dockerized version of nginx-lws that is self-contained and includes the nginx-lws web server,
+all its required dependencies, and the Examples website from this repository.
 
-## Examples Website Configuration
+This Docker image is designed for easy deployment, providing users with a straightforward command
+to quickly test and explore the full range of capabilities offered by nginx-lws.
+It runs on an Ubuntu 20.04 (Focal Fossa) image.
+
+### Dependencies
+- Docker
+
+### Running the Examples website
+To start the Examples website, simply execute the following commands from the root directory:
+```
+docker compose build
+docker compose up -d
+```
+Once these commands have been executed, you can access the website by navigating to http://localhost:8080 in your web browser.
+
+
+## Running Examples website from scratch
+### Examples Website Configuration
 
 The configuration provided with the examples is called `lws-examples.conf` and looks similar to
 this:
@@ -66,7 +86,7 @@ during local development to pick up code changes.
 For more information, please refer to the [directives](Directives.md) documentation.
 
 
-## Enabling the Examples Website
+### Enabling the Examples Website
 
 The exact steps to enable the website with the examples depend on the specifics of your NGINX
 installation.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.9'
+
+services:
+  lws-example:
+    image: nginx-lws:${TAG:-local}
+    command: [ './nginx-entrypoint.sh' ]
+    platform: linux/amd64
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      target: runtime
+    ports:
+      - "8080:80"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,64 @@
+from ubuntu:focal as base
+
+ENV LUA_VERSION=5.3
+ENV NGINX_VERSION=1.18.0
+
+RUN apt-get update && \
+    apt-get install -y \
+    tzdata \
+    locales
+
+# configure local and timezone
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+RUN locale-gen en_US.UTF-8 \
+    && echo $LANG > /etc/default/locale
+
+RUN apt-get update && \
+    apt-get install -y \
+    lua${LUA_VERSION} \
+    liblua${LUA_VERSION}-dev \
+    nginx=${NGINX_VERSION}-0ubuntu1.4 \
+    curl
+
+
+#####################################################
+
+from base as build
+
+RUN apt-get update && \
+    apt-get install -y \
+    zlib1g-dev \
+    libpcre3-dev \
+    make
+
+RUN mkdir nginx-lws
+
+RUN curl -LO https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz
+RUN tar -zxvf nginx-${NGINX_VERSION}.tar.gz
+
+COPY ./ nginx-lws/
+
+WORKDIR nginx-${NGINX_VERSION}
+RUN ./configure --with-compat --with-threads --add-dynamic-module=../nginx-lws
+RUN make modules
+
+#####################################################
+
+from base as runtime
+
+COPY --from=build \
+  ./nginx-${NGINX_VERSION}/objs/lws_module.so \
+  /usr/lib/nginx/modules/
+
+COPY examples/lws-examples.conf /etc/nginx/sites-available/default
+COPY etc/lws.conf /etc/nginx/modules-enabled/lws.conf
+
+COPY examples/ /var/www/lws-examples/
+COPY docker/nginx-entrypoint.sh .
+
+EXPOSE 8080
+
+CMD echo "COMMAND IS NOT SET UP"

--- a/docker/nginx-entrypoint.sh
+++ b/docker/nginx-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+service nginx start
+
+# Check if Nginx is running and restart it if necessary
+while true; do
+    if ! service nginx status >/dev/null 2>&1; then
+        service nginx start
+    fi
+    sleep 60
+done

--- a/examples/lws-examples.conf
+++ b/examples/lws-examples.conf
@@ -1,5 +1,4 @@
 server {
-	listen localhost:8080;
 
 	location / {
 		alias /var/www/lws-examples/static/;


### PR DESCRIPTION
Add the necessary docker files to build lws and run the Examples website easier.